### PR TITLE
Fetch nauty

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,14 +74,13 @@ class InstallNauty(Command):
             urllib.request.urlretrieve(
                 f"http://users.cecs.anu.edu.au/~bdm/nauty/nauty{nauty_version}.tar.gz",
                 f"nauty{nauty_version}.tar.gz",)
-        print("Extracting nauty.")
-        with tarfile.open(f"nauty{nauty_version}.tar.gz") as tar:
-            tar.extractall(cwd)
-            os.rename(os.path.join(cwd,f"nauty{nauty_version}"), nauty_dir)
+        if not os.path.exists(os.path.join(nauty_dir,'nauty.c')):
+            print("Extracting nauty.")
+            with tarfile.open(f"nauty{nauty_version}.tar.gz") as tar:
+                tar.extractall(cwd)
+                os.rename(os.path.join(cwd,f"nauty{nauty_version}"), nauty_dir)
         print("Building nauty")
-        subprocess.check_call(
-            ["make", "nauty"], cwd=nauty_dir
-           )
+        subprocess.check_call(["make", "nauty-objects"], cwd=cwd)
 
 class InstallCommand(install):
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,13 @@ cwd = os.getcwd()
 nauty_dir       = os.path.join(cwd,'nauty')
 nauty_version   = '27r1'
 
+def deltree(target):
+    for d in os.listdir(target):
+        try:
+            deltree(os.path.join(target,d))
+        except OSError:
+            os.remove(os.path.join(target,d))
+
 class InstallNauty(Command):
     """Fetch and install nauty, if not present already"""
     description = "ensure nauty is built"
@@ -66,15 +73,15 @@ class InstallNauty(Command):
         Fetches and installs nauty.
         """
         if os.path.exists(os.path.join(nauty_dir,'nauty.o')):
-            #todo: add version check
+            #todo: maybe add a check for the nauty version
             return
 
         if not os.path.exists(os.path.join(cwd,f"nauty{nauty_version}.tar.gz")):
+            deltree(nauty_dir)
             print("Fetching nauty.")
             urllib.request.urlretrieve(
                 f"http://users.cecs.anu.edu.au/~bdm/nauty/nauty{nauty_version}.tar.gz",
                 f"nauty{nauty_version}.tar.gz",)
-        if not os.path.exists(os.path.join(nauty_dir,'nauty.c')):
             print("Extracting nauty.")
             with tarfile.open(f"nauty{nauty_version}.tar.gz") as tar:
                 tar.extractall(cwd)


### PR DESCRIPTION
This adds a command in the installer that fetches and builds nauty automatically.

Unfortunately, nauty does not seem to have the full version number as string anywhere in the files, so I'm using the existence of the tarball as version check.

I tested this and it worked well on my setup (on a clean virtualenv on Python 3.9 on linux). We should still add some CI via github actions to test and build it on different platforms, but I'd make a different PR for that.

Closes #1 