### PR TITLE
Refactor makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 PYTHON = python3
 PIP = $(PYTHON) -m pip
 
-PYNAUTY_VERSION = $(shell $(PYTHON) -m src.pynauty pynauty-version)
-NAUTY_VERSION = $(shell $(PYTHON) -m src.pynauty nauty-version)
-NAUTY_TARFILE = $(shell $(PYTHON) -m src.pynauty nauty-tarfile)
-NAUTY_SHA1SUM = $(shell $(PYTHON) -m src.pynauty nauty-checksum)
-NAUTY_URL = $(shell $(PYTHON) -m src.pynauty nauty-url)
-NAUTY_DIR = $(shell $(PYTHON) -m src.pynauty nauty-dir)
+SOURCE_DIR = src
+PYNAUTY_VERSION = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty pynauty-version)
+NAUTY_VERSION = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty nauty-version)
+NAUTY_TARFILE = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty nauty-tarfile)
+NAUTY_SHA1SUM = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty nauty-checksum)
+NAUTY_URL = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty nauty-url)
+NAUTY_DIR = $(shell $(PYTHON) -m $(SOURCE_DIR).pynauty nauty-dir)
 
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell $(PYTHON) --version 2>&1)))
 python_version_major := $(word 1,${python_version_full})
@@ -116,26 +117,23 @@ GTOOLS = copyg listg labelg dretog amtog geng complg shortg showg NRswitchg \
   multig planarg gentourng ranlabg runalltests subdivideg watercluster2 \
   linegraphg naucompare
 
-.PHONY: fetch-nauty
 fetch-nauty:
-	cd src/; make fetch-nauty
+	cd $(SOURCE_DIR); make $@
 
-nauty-config: $(NAUTY_DIR)/config.log
-$(NAUTY_DIR)/config.log: fetch-nauty
-	cd $(NAUTY_DIR); ./configure CFLAGS='-O4 -fPIC'
+nauty-config:
+	cd $(SOURCE_DIR); make $@
 
-nauty-objects: nauty-config
-	cd $(NAUTY_DIR); make nauty.o nautil.o naugraph.o schreier.o naurng.o
+nauty-objects:
+	cd $(SOURCE_DIR); make $@
 
-nauty-programs: nauty-config
-	cd $(NAUTY_DIR); make
+nauty-programs:
+	cd $(SOURCE_DIR); make $@
 
 clean-nauty:
-	cd $(NAUTY_DIR); rm -f *.o dreadnaut ${GTOOLS} nauty.a nauty1.a
-	cd $(NAUTY_DIR); rm -f makefile config.log config.status gtools.h naututil.h nauty.h
+	cd $(SOURCE_DIR); make $@
 
 remove-nauty:
-	cd src/; make clean
+	cd $(SOURCE_DIR); make $@
 
 clobber: clean remove-nauty clean-docs
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ help:
 	@echo '  clean-docs     - remove pyanauty documentation'
 	@echo '  fetch-nauty    - download Nauty source files'
 	@echo '  nauty-objects  - compile only nauty.o nautil.o naugraph.o schreier.o naurng.o'
-	@echo '  nauty-progs    - build all nauty programs'
 	@echo '  clean-nauty    - a "distclean" for nauty'
 	@echo '  remove-nauty   - remove all nauty related files'
 	@echo '  clobber        - clean + remove-nauty + clean-docs'
@@ -110,12 +109,7 @@ clean: virtenv-delete
 	rm -fr .pytest_cache/
 	rm -fr pynauty.egg-info
 
-# nauty stuff
-
-GTOOLS = copyg listg labelg dretog amtog geng complg shortg showg NRswitchg \
-  biplabg addedgeg deledgeg countg pickg genrang newedgeg catg genbg directg \
-  multig planarg gentourng ranlabg runalltests subdivideg watercluster2 \
-  linegraphg naucompare
+# nauty targets
 
 fetch-nauty:
 	cd $(SOURCE_DIR); make $@

--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ To build and test the package:
   make tests
 ```
 
-To install the `pynauty` package in `~/.local` (home install) and then
-to generate the documentation:
-
-```bash
-  make user-ins
-  make docs
-```
-
 It is also possible to install into a virtual environment. 
 
 ```bash
@@ -51,7 +43,17 @@ It is also possible to install into a virtual environment.
   To activate it type: source ./.venv-pynauty/bin/activate
   % source .venv-pynauty/bin/activate
   (.venv-pynauty) % make virtenv-ins
+  (.venv-pynauty) % make virtenv-tests
   ...
+```
+
+Install the `pynauty` package in `~/.local` (home install) then generate
+the documentation. Building the documentation from source requires the
+Sphinx package.
+
+```bash
+  make user-ins
+  make docs
 ```
 
 Invoking `make` without arguments will list many more targets.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ packages        = [ MODULE ]
 scripts         = []
 data_files      = []
 
-nauty_dir       = 'src/' + pynauty._nauty_version
+nauty_dir       = 'src/' + pynauty._nauty_dir
 if not os.access(nauty_dir, os.R_OK | os.X_OK):
     print("Can't find nauty_dir: %s" % nauty_dir)
     raise SystemExit(1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,24 +19,39 @@ endif
 help:
 	@echo Available targets:
 	@echo ' fetch-nauty  - fetch nauty source distribution'
-	@echo ' clean        - delete nauty source and related files'
+	@echo ' remove-nauty - delete nauty source and related files'
 	@echo
 	@echo 'Pynauty version:' ${PYNAUTY_VERSION}
 	@echo 'Nauty version:  ' ${NAUTY_VERSION}
+	@echo 'Nauty directory:' ${NAUTY_DIR}
 	@echo 'Nauty source:   ' ${NAUTY_URL}
 	@echo 'Nauty tarfile:  ' ${NAUTY_TARFILE}
 	@echo 'Nauty checksum :' ${NAUTY_SHA1SUM}
 
-.PHONY: fetch-nauty
 fetch-nauty:
 ifeq (,$(wildcard ./${NAUTY_TARFILE}))
 	curl -O ${NAUTY_URL}
 	@if $(SHA1SUM) -c --status ${NAUTY_SHA1SUM}; then tar xf ${NAUTY_TARFILE}; else rm -f ${NAUTY_TARFILE}; fi
 else
-	@if $(SHA1SUM) -c --status ${NAUTY_SHA1SUM}; then tar xf ${NAUTY_TARFILE}; else echo checksum failed; rm -f ${NAUTY_TARFILE}; echo download again; fi
+	@if $(SHA1SUM) -c --status ${NAUTY_SHA1SUM}; then tar xf ${NAUTY_TARFILE}; else echo "ERROR: checksum failed." ; rm -f ${NAUTY_TARFILE}; echo " ===> run fetch-nauty again!" ; fi
 endif
 
-.PHONY: clean
-clean:
-	rm -fr ${NAUTY_VERSION}
+$(NAUTY_DIR)/configure.ac: | fetch-nauty
+
+nauty-config: $(NAUTY_DIR)/config.log
+$(NAUTY_DIR)/config.log: $(NAUTY_DIR)/configure.ac
+	cd $(NAUTY_DIR); ./configure CFLAGS='-O4 -fPIC'
+
+nauty-objects: nauty-config
+	cd $(NAUTY_DIR); make nauty.o nautil.o naugraph.o schreier.o naurng.o
+
+nauty-programs: nauty-config
+	cd $(NAUTY_DIR); make
+
+clean-nauty:
+	cd $(NAUTY_DIR); rm -f *.o dreadnaut ${GTOOLS} nauty.a nauty1.a
+	cd $(NAUTY_DIR); rm -f makefile config.log config.status gtools.h naututil.h nauty.h
+
+remove-nauty:
+	rm -fr ${NAUTY_DIR}
 	rm -f ${NAUTY_TARFILE}

--- a/src/Makefile
+++ b/src/Makefile
@@ -18,8 +18,11 @@ endif
 
 help:
 	@echo Available targets:
-	@echo ' fetch-nauty  - fetch nauty source distribution'
-	@echo ' remove-nauty - delete nauty source and related files'
+	@echo '  fetch-nauty    - download Nauty source files'
+	@echo '  nauty-objects  - compile only nauty.o nautil.o naugraph.o schreier.o naurng.o'
+	@echo '  nauty-programs - build all nauty programs'
+	@echo '  clean-nauty    - a "distclean" for nauty'
+	@echo '  remove-nauty   - remove all nauty related files'
 	@echo
 	@echo 'Pynauty version:' ${PYNAUTY_VERSION}
 	@echo 'Nauty version:  ' ${NAUTY_VERSION}
@@ -47,6 +50,11 @@ nauty-objects: nauty-config
 
 nauty-programs: nauty-config
 	cd $(NAUTY_DIR); make
+
+GTOOLS = copyg listg labelg dretog amtog geng complg shortg showg NRswitchg \
+  biplabg addedgeg deledgeg countg pickg genrang newedgeg catg genbg directg \
+  multig planarg gentourng ranlabg runalltests subdivideg watercluster2 \
+  linegraphg naucompare
 
 clean-nauty:
 	cd $(NAUTY_DIR); rm -f *.o dreadnaut ${GTOOLS} nauty.a nauty1.a

--- a/src/pynauty/__init__.py
+++ b/src/pynauty/__init__.py
@@ -35,7 +35,7 @@ _nauty_tarfile   = _nauty_version + '.tar.gz'
 _nauty_checksum  = _nauty_tarfile + '.sha1sum'
 _nauty_url       = 'https://cs.anu.edu.au/people/Brendan.McKay/nauty/' + _nauty_tarfile
 _nauty_url       = 'https://pallini.di.uniroma1.it/' + _nauty_tarfile
-_nauty_dir       = 'src/' + _nauty_version
+_nauty_dir       = _nauty_version   # relative to src/
 
 _pynauty_version = '1.0b1'
 __version__      = _pynauty_version + '+' + _nauty_version


### PR DESCRIPTION
Completely separate `pynauty` and `nauty` targets into different Makefiles.
Eliminate some unnecessary rebuilds.

Tests can be run with either loading from `build/` or from an active virtualenv.