### PR TITLE
Fix memory leak (see #32 and #40)

### DIFF
--- a/src/pynauty/nautywrap.c
+++ b/src/pynauty/nautywrap.c
@@ -234,6 +234,7 @@ static int set_partition(PyObject *py_graph, int *lab, int *ptn)
     }
 
     if ((no_parts = PyObject_Length(partition)) <= 0) {
+        Py_DECREF(partition);
         return -1;      // no coloring
     }
 
@@ -357,12 +358,12 @@ NyGraph * _make_nygraph(PyObject *py_graph)
         PyErr_SetString(PyExc_TypeError, "missing 'directed' attribute");
         return NULL;
     }
-    Py_DECREF(p);
     if (PyObject_IsTrue(p)) {
         g->options->digraph = TRUE;
     } else {
         g->options->digraph = FALSE;
     }
+    Py_DECREF(p);
 
     // get the adjacency list dictionary object
     if ((adjdict = PyObject_GetAttrString(py_graph, "adjacency_dict")) == NULL) {


### PR DESCRIPTION
In #40, a minor memory leak was noticed. This leak happened to be much smaller than this from #32, but also much more common. It was present in at least `autgrp`, `certificate`, `canon_label` and `nautywrap.make_nygraph` combined with `nautywrap.delete_nygraph`. The culprit was a missing `Py_DECREF` in `set_partition` if no partition was provided.

This also fixes a small potential use after free of `graph.directed` in `_make_nygraph`.